### PR TITLE
fix bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools
 numpy>=1.8
-scipy>=0.14
+scipy>=0.14, <=1.7.0


### PR DESCRIPTION
scipy.linalg.pinv2() depecrated after 1.7.0